### PR TITLE
Fix folder names with build version

### DIFF
--- a/build-bitoreum.sh
+++ b/build-bitoreum.sh
@@ -122,27 +122,6 @@ make -j$(nproc) HOST=${HOST_TRIPLE} 2>&1 | tee build.log
 
 # === Configure and build ===
 cd ..
-touch build.log config.log
-./autogen.sh
-./configure --prefix="$(pwd)/depends/${HOST_TRIPLE}" 2>&1 | tee config.log
-make -j$(nproc) 2>&1 | tee build.log
-
-# === Copy and organize outputs ===
-BUILD_DIR="$HOME/bitoreum-build/build"
-COMPRESS_DIR="$HOME/bitoreum-build/compressed"
-mkdir -p "${BUILD_DIR}/bitoreum-build" "${BUILD_DIR}_not_strip/bitoreum-build" "${BUILD_DIR}_debug/bitoreum-build" "$COMPRESS_DIR"
-
-cp src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}/bitoreum-build"
-mv src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}_not_strip/bitoreum-build"
-strip "${BUILD_DIR}/bitoreum-build/"*
-
-# === Build debug version ===
-make clean && make distclean
-touch build_debug.log config_debug.log
-./autogen.sh
-./configure --prefix="$(pwd)/depends/${HOST_TRIPLE}" --disable-tests --enable-debug 2>&1 | tee config_debug.log
-make -j$(nproc) 2>&1 | tee build_debug.log
-mv src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}_debug/bitoreum-build"
 
 # === Get version string ===
 if [[ -f build.properties ]]; then
@@ -152,6 +131,29 @@ else
     echo "release-version=$VERSION" > build.properties
     log "Warning, build.properties not found — using fallback version: $VERSION"
 fi
+BIN_SUBDIR="bitoreum-v${VERSION}"
+
+touch build.log config.log
+./autogen.sh
+./configure --prefix="$(pwd)/depends/${HOST_TRIPLE}" 2>&1 | tee config.log
+make -j$(nproc) 2>&1 | tee build.log
+
+# === Copy and organize outputs ===
+BUILD_DIR="$HOME/bitoreum-build/build"
+COMPRESS_DIR="$HOME/bitoreum-build/compressed"
+mkdir -p "${BUILD_DIR}/${BIN_SUBDIR}" "${BUILD_DIR}_not_strip/${BIN_SUBDIR}" "${BUILD_DIR}_debug/${BIN_SUBDIR}" "$COMPRESS_DIR"
+
+cp src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}/${BIN_SUBDIR}"
+mv src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}_not_strip/${BIN_SUBDIR}"
+strip "${BUILD_DIR}/${BIN_SUBDIR}/"*
+
+# === Build debug version ===
+make clean && make distclean
+touch build_debug.log config_debug.log
+./autogen.sh
+./configure --prefix="$(pwd)/depends/${HOST_TRIPLE}" --disable-tests --enable-debug 2>&1 | tee config_debug.log
+make -j$(nproc) 2>&1 | tee build_debug.log
+mv src/bitoreum-cli src/bitoreumd src/bitoreum-tx src/qt/bitoreum-qt "${BUILD_DIR}_debug/${BIN_SUBDIR}"
 
 COIN_NAME=bitoreum
 if $PI4_BUILD; then
@@ -166,22 +168,24 @@ OS="$(. /etc/os-release && echo "${ID}-${VERSION_ID}")"
 # === Compress and checksum ===
 for TYPE in "" "_debug" "_not_strip"; do
     OUTER_DIR="${BUILD_DIR}${TYPE}"
-    BIN_DIR="${OUTER_DIR}/bitoreum-build"
+    BIN_DIR="${OUTER_DIR}/${BIN_SUBDIR}"
     CHECKSUM_FILE="${BIN_DIR}/checksums-${VERSION}.txt"
 
-    cd "$BIN_DIR" || continue
+    cd "$OUTER_DIR" || continue
 
     echo "sha256:" > "$CHECKSUM_FILE"
-    find . -type f -exec shasum {} \; >> "$CHECKSUM_FILE"
+    # Use SHA-256 for cross-platform consistency. "shasum" defaults to
+    # SHA-1 which mismatches the "sha256" label.
+    find "$BIN_SUBDIR" -type f -exec shasum -a 256 {} \; >> "$CHECKSUM_FILE"
     echo "openssl-sha256:" >> "$CHECKSUM_FILE"
-    find . -type f -exec sha256sum {} \; >> "$CHECKSUM_FILE"
+    find "$BIN_SUBDIR" -type f -exec sha256sum {} \; >> "$CHECKSUM_FILE"
 
     echo -e "\n📂 Contents of $BIN_DIR:"
-    ls -lh
+    ls -lh "$BIN_DIR"
 
-    if [[ -f bitoreumd && -f bitoreum-cli ]]; then
+    if [[ -f "${BIN_DIR}/bitoreumd" && -f "${BIN_DIR}/bitoreum-cli" ]]; then
         ARCHIVE_NAME="${COIN_NAME}-${OS}_${ARCH_TYPE}${TYPE}-${VERSION}.tar.gz"
-        tar -cf - . | gzip -9 > "${COMPRESS_DIR}/${ARCHIVE_NAME}" || err "tar failed for $TYPE"
+        tar -cf - "$BIN_SUBDIR" | gzip -9 > "${COMPRESS_DIR}/${ARCHIVE_NAME}" || err "tar failed for $TYPE"
         log "Compressed: $ARCHIVE_NAME"
     else
         err "Missing binaries in $BIN_DIR — skipping compression."
@@ -193,7 +197,8 @@ cd "$COMPRESS_DIR"
 if ls *.tar.gz >/dev/null 2>&1; then
     GLOBAL_SUM="checksums-${VERSION}.txt"
     for FILE in *.tar.gz; do
-        echo "sha256: $(shasum "$FILE")" >> "$GLOBAL_SUM"
+        # Again ensure SHA-256 is used when generating archive level checksums
+        echo "sha256: $(shasum -a 256 "$FILE")" >> "$GLOBAL_SUM"
         echo "openssl-sha256: $(sha256sum "$FILE")" >> "$GLOBAL_SUM"
     done
     log "Compression complete. Files saved in $COMPRESS_DIR"


### PR DESCRIPTION
## Summary
- store binaries in directories named `bitoreum-v<version>`
- compute release version before building
- compress archives so that `bitoreum-v<version>` folder is included

## Testing
- `bash -n build-bitoreum.sh`


------
https://chatgpt.com/codex/tasks/task_e_68698da63b8883269961ccb44d1c9934